### PR TITLE
Fix TS2307 on building

### DIFF
--- a/packages/adblocker-playwright/tsconfig.json
+++ b/packages/adblocker-playwright/tsconfig.json
@@ -6,7 +6,8 @@
   },
   "references": [
     { "path": "../adblocker/tsconfig.json" },
-    { "path": "../adblocker-content/tsconfig.json" }
+    { "path": "../adblocker-content/tsconfig.json" },
+    { "path": "../adblocker-e2e/tsconfig.json" }
   ],
   "include": [
     "./test/**/*.ts",

--- a/packages/adblocker-puppeteer/tsconfig.json
+++ b/packages/adblocker-puppeteer/tsconfig.json
@@ -6,7 +6,8 @@
   },
   "references": [
     { "path": "../adblocker/tsconfig.json" },
-    { "path": "../adblocker-content/tsconfig.json" }
+    { "path": "../adblocker-content/tsconfig.json" },
+    { "path": "../adblocker-e2e/tsconfig.json" }
   ],
   "include": [
     "./test/**/*.ts",


### PR DESCRIPTION
```
Error: packages/adblocker-puppeteer/test/adblocker.test.ts(6,22): error TS2307: Cannot find module '@cliqz/adblocker-e2e' or its corresponding type declarations.
Error: packages/adblocker-playwright/test/adblocker.test.ts(5,22): error TS2307: Cannot find module '@cliqz/adblocker-e2e' or its corresponding type declarations.
```