### PR TITLE
feat: perform html filtering on headers received

### DIFF
--- a/packages/adblocker-webextension/package.json
+++ b/packages/adblocker-webextension/package.json
@@ -37,7 +37,8 @@
     "clean": "rimraf dist coverage .tshy .tshy-build .nyc_output .rollup.cache",
     "lint": "eslint src test",
     "build": "tshy && rollup --config ./rollup.config.js",
-    "test": "nyc mocha"
+    "test": "nyc mocha",
+    "dev": "mocha --watch"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/adblocker-webextension/src/index.ts
+++ b/packages/adblocker-webextension/src/index.ts
@@ -153,6 +153,13 @@ export function shouldApplyReplaceSelectors(
 ): boolean {
   const details = request._originalRequestDetails as OnHeadersReceivedDetailsType;
   if (
+    details.responseHeaders
+      ?.find((header) => header.name.toLowerCase() === 'content-disposition')
+      ?.value?.startsWith('inline') === true
+  ) {
+    return false;
+  }
+  if (
     parseInt(
       details.responseHeaders?.find((header) => header.name.toLowerCase() === 'content-length')
         ?.value ?? '0',

--- a/packages/adblocker-webextension/src/index.ts
+++ b/packages/adblocker-webextension/src/index.ts
@@ -155,7 +155,7 @@ export function shouldApplyReplaceSelectors(
   if (
     details.responseHeaders
       ?.find((header) => header.name.toLowerCase() === 'content-disposition')
-      ?.value?.startsWith('inline') === true
+      ?.value?.startsWith('inline') === false
   ) {
     return false;
   }

--- a/packages/adblocker-webextension/src/index.ts
+++ b/packages/adblocker-webextension/src/index.ts
@@ -131,7 +131,7 @@ export function updateResponseHeadersWithCSP(
   return { responseHeaders };
 }
 
-const readableMimeTypes = new Set([
+const READABLE_MIME_TYPES = new Set([
   'application/javascript',
   'application/json',
   'application/mpegurl',
@@ -162,7 +162,7 @@ export function isRequestHTMLFilterable(
     }
   } else if (contentTypeFromHeader.startsWith('text')) {
     return true;
-  } else if (readableMimeTypes.has(contentTypeFromHeader)) {
+  } else if (READABLE_MIME_TYPES.has(contentTypeFromHeader)) {
     return true;
   }
   return false;

--- a/packages/adblocker-webextension/src/index.ts
+++ b/packages/adblocker-webextension/src/index.ts
@@ -27,7 +27,14 @@ export type OnBeforeRequestDetailsType = Pick<
 
 export type OnHeadersReceivedDetailsType = Pick<
   WebRequest.OnHeadersReceivedDetailsType,
-  'responseHeaders' | 'url' | 'type' | 'tabId' | 'requestId' | 'originUrl' | 'documentUrl'
+  | 'responseHeaders'
+  | 'url'
+  | 'type'
+  | 'tabId'
+  | 'requestId'
+  | 'originUrl'
+  | 'documentUrl'
+  | 'statusCode'
 > & {
   initiator?: string; // Chromium only
 };
@@ -152,6 +159,15 @@ export function shouldApplyReplaceSelectors(
   request: Request<OnBeforeRequestDetailsType | OnHeadersReceivedDetailsType>,
 ): boolean {
   const details = request._originalRequestDetails as OnHeadersReceivedDetailsType;
+  // In case of undefined error of xhr/fetch and any kind of network activities
+  if (details.statusCode === 0) {
+    return false;
+  }
+  // If status code is non 2xx or 4xx, 5xx
+  const statusCodeScope = (details.statusCode / 100) >>> 0;
+  if (statusCodeScope !== 2 && statusCodeScope < 4) {
+    return false;
+  }
   if (
     details.responseHeaders
       ?.find((header) => header.name.toLowerCase() === 'content-disposition')

--- a/packages/adblocker-webextension/src/index.ts
+++ b/packages/adblocker-webextension/src/index.ts
@@ -158,7 +158,7 @@ function isResponseHeadersAvailable(
 export function shouldApplyReplaceSelectors(
   request: Request<OnBeforeRequestDetailsType | OnHeadersReceivedDetailsType>,
 ): boolean {
-  if (isResponseHeadersAvailable(request._originalRequestDetails!)) {
+  if (isResponseHeadersAvailable(request._originalRequestDetails)) {
     if (
       parseInt(
         request._originalRequestDetails.responseHeaders?.find(

--- a/packages/adblocker-webextension/src/index.ts
+++ b/packages/adblocker-webextension/src/index.ts
@@ -148,7 +148,7 @@ const READABLE_MIME_TYPES = new Set([
 ]);
 const MAXIMUM_RESPONSE_BUFFER_SIZE = 10 * 1024 * 1024;
 
-export function isRequestHTMLFilterable(
+export function shouldApplyReplaceSelectors(
   request: Request,
   details: OnHeadersReceivedDetailsType,
 ): boolean {
@@ -177,13 +177,8 @@ export function filterRequestHTML(
   request: Request,
   rules: HTMLSelector[],
 ): void {
-  const replaceFilterIndex = rules.findIndex(([type]) => type === 'replace');
-  // If `replace` filters are not supported
-  if (
-    isRequestHTMLFilterable(request, request._originalRequestDetails) === false &&
-    replaceFilterIndex !== -1
-  ) {
-    rules.splice(replaceFilterIndex);
+  if (shouldApplyReplaceSelectors(request, request._originalRequestDetails) === false) {
+    rules = rules.filter(([type]) => type !== 'replace');
   }
   if (rules.length === 0) {
     return;

--- a/packages/adblocker-webextension/src/index.ts
+++ b/packages/adblocker-webextension/src/index.ts
@@ -464,10 +464,9 @@ export class WebExtensionBlocker extends FiltersEngine {
       typeof TextEncoder !== 'undefined'
     ) {
       const htmlFilters = this.getHtmlFilters(request);
-      if (htmlFilters.length === 0) {
-        return;
+      if (htmlFilters.length !== 0) {
+        filterRequestHTML(browser.webRequest.filterResponseData, request, htmlFilters);
       }
-      filterRequestHTML(browser.webRequest.filterResponseData, request, htmlFilters);
     }
   }
 

--- a/packages/adblocker-webextension/src/index.ts
+++ b/packages/adblocker-webextension/src/index.ts
@@ -459,14 +459,6 @@ export class WebExtensionBlocker extends FiltersEngine {
         return;
       }
       const replaceFilterIndex = htmlFilters.findIndex(([type]) => type === 'replace');
-      // If `script:has-text` filters are not supported
-      if (request.isMainFrame() === false) {
-        if (replaceFilterIndex === -1) {
-          return;
-        } else {
-          htmlFilters.splice(0, replaceFilterIndex);
-        }
-      }
       // If `replace` filters are not supported
       if (isRequestHTMLFilterable(request, details) === false && replaceFilterIndex !== -1) {
         htmlFilters.splice(replaceFilterIndex);

--- a/packages/adblocker-webextension/src/index.ts
+++ b/packages/adblocker-webextension/src/index.ts
@@ -152,18 +152,28 @@ export function shouldApplyReplaceSelectors(
   request: Request,
   details: OnHeadersReceivedDetailsType,
 ): boolean {
-  const contentTypeFromHeader = details.responseHeaders?.find(
+  const contentTypeHeader = details.responseHeaders?.find(
     (header) => header.name.toLowerCase() === 'content-type',
   )?.value;
-  if (contentTypeFromHeader === undefined) {
+  // Content-Length includes the length of octets which is consisted of 8 bytes with endianness
+  const contentLengthHeader = details.responseHeaders?.find(
+    (header) => header.name.toLowerCase() === 'content-length',
+  )?.value;
+  if (
+    contentLengthHeader !== undefined &&
+    parseInt(contentLengthHeader, 10) >= MAXIMUM_RESPONSE_BUFFER_SIZE
+  ) {
+    return false;
+  }
+  if (contentTypeHeader === undefined) {
     if (request.type === 'stylesheet' || request.type === 'script') {
       return true;
     } else {
       return false;
     }
-  } else if (contentTypeFromHeader.startsWith('text')) {
+  } else if (contentTypeHeader.startsWith('text')) {
     return true;
-  } else if (READABLE_MIME_TYPES.has(contentTypeFromHeader)) {
+  } else if (READABLE_MIME_TYPES.has(contentTypeHeader)) {
     return true;
   }
   return false;

--- a/packages/adblocker-webextension/src/index.ts
+++ b/packages/adblocker-webextension/src/index.ts
@@ -209,7 +209,9 @@ export function filterRequestHTML(
     //
     // In case any data remains, we write it to filter.
     try {
-      const remaining = htmlFilter.write(decoder.decode()) + htmlFilter.flush();
+      const remaining =
+        htmlFilter.write(decoder.decode()) +
+        htmlFilter.flush(accumulatedBufferSize < MAXIMUM_RESPONSE_BUFFER_SIZE);
       if (remaining.length !== 0) {
         filter.write(encoder.encode(remaining));
       }

--- a/packages/adblocker-webextension/src/index.ts
+++ b/packages/adblocker-webextension/src/index.ts
@@ -148,36 +148,27 @@ const HTML_FILTERABLE_MIME_TYPES = new Set([
 ]);
 export const MAXIMUM_RESPONSE_BUFFER_SIZE = 10 * 1024 * 1024;
 
-function isResponseHeadersAvailable(
-  details: OnBeforeRequestDetailsType | OnHeadersReceivedDetailsType,
-): details is OnHeadersReceivedDetailsType {
-  // @ts-expect-error `responseHeaders` is only available for OnHeadersReceivedDetailsType
-  return details.responseHeaders !== undefined;
-}
-
 export function shouldApplyReplaceSelectors(
   request: Request<OnBeforeRequestDetailsType | OnHeadersReceivedDetailsType>,
 ): boolean {
-  if (isResponseHeadersAvailable(request._originalRequestDetails)) {
-    if (
-      parseInt(
-        request._originalRequestDetails.responseHeaders?.find(
-          (header) => header.name.toLowerCase() === 'content-length',
-        )?.value ?? '0',
-        10,
-      ) >= MAXIMUM_RESPONSE_BUFFER_SIZE
-    ) {
-      return false;
-    }
-    const contentTypeHeader = request._originalRequestDetails.responseHeaders?.find(
-      (header) => header.name.toLowerCase() === 'content-type',
-    )?.value;
-    if (contentTypeHeader !== undefined) {
-      if (contentTypeHeader.startsWith('text')) {
-        return true;
-      } else if (HTML_FILTERABLE_MIME_TYPES.has(contentTypeHeader)) {
-        return true;
-      }
+  const details = request._originalRequestDetails as OnHeadersReceivedDetailsType;
+  if (
+    parseInt(
+      details.responseHeaders?.find((header) => header.name.toLowerCase() === 'content-length')
+        ?.value ?? '0',
+      10,
+    ) >= MAXIMUM_RESPONSE_BUFFER_SIZE
+  ) {
+    return false;
+  }
+  const contentTypeHeader = details.responseHeaders?.find(
+    (header) => header.name.toLowerCase() === 'content-type',
+  )?.value;
+  if (contentTypeHeader !== undefined) {
+    if (contentTypeHeader.startsWith('text')) {
+      return true;
+    } else if (HTML_FILTERABLE_MIME_TYPES.has(contentTypeHeader)) {
+      return true;
     }
   }
 

--- a/packages/adblocker-webextension/src/index.ts
+++ b/packages/adblocker-webextension/src/index.ts
@@ -176,8 +176,7 @@ function getHeaderFromDetails(
   details: OnHeadersReceivedDetailsType,
   headerName: WebRequest.HttpHeadersItemType['name'],
 ): string | undefined {
-  return details.responseHeaders?.find((header) => header.name.toLowerCase() === headerName)
-    ?.value;
+  return details.responseHeaders?.find((header) => header.name === headerName)?.value;
 }
 
 // $replace filters are applied to complete response bodies

--- a/packages/adblocker-webextension/src/index.ts
+++ b/packages/adblocker-webextension/src/index.ts
@@ -146,7 +146,7 @@ const READABLE_MIME_TYPES = new Set([
   'audio/mpegurl',
   'audio/x-mpegurl',
 ]);
-const MAXIMUM_RESPONSE_BUFFER_SIZE = 10 * 1024 * 1024;
+export const MAXIMUM_RESPONSE_BUFFER_SIZE = 10 * 1024 * 1024;
 
 export function shouldApplyReplaceSelectors(
   request: Request,

--- a/packages/adblocker-webextension/src/index.ts
+++ b/packages/adblocker-webextension/src/index.ts
@@ -174,8 +174,7 @@ export function shouldApplyReplaceSelectors(
   }
 
   // If status code is non 2xx or 4xx, 5xx
-  const statusCodeScope = (details.statusCode / 100) >>> 0;
-  if (statusCodeScope !== 2 && statusCodeScope < 4) {
+  if (details.statusCode < 200 || details.statusCode > 299) {
     return false;
   }
 

--- a/packages/adblocker-webextension/src/index.ts
+++ b/packages/adblocker-webextension/src/index.ts
@@ -25,10 +25,12 @@ export type OnBeforeRequestDetailsType = Pick<
   initiator?: string; // Chromium only
 };
 
-type OnHeadersReceivedDetailsType = Pick<
+export type OnHeadersReceivedDetailsType = Pick<
   WebRequest.OnHeadersReceivedDetailsType,
-  'responseHeaders' | 'url' | 'type' | 'tabId' | 'requestId'
->;
+  'responseHeaders' | 'url' | 'type' | 'tabId' | 'requestId' | 'originUrl' | 'documentUrl'
+> & {
+  initiator?: string; // Chromium only
+};
 
 type StreamFilter = WebRequest.StreamFilter & {
   onstart: (event: any) => void;
@@ -79,7 +81,6 @@ const USE_PUSH_SCRIPTS_INJECTION = usePushScriptsInjection();
 export function fromWebRequestDetails(
   details: OnBeforeRequestDetailsType | OnHeadersReceivedDetailsType,
 ): Request {
-  // @ts-expect-error
   const sourceUrl = details.initiator || details.originUrl || details.documentUrl;
   return Request.fromRawDetails(
     sourceUrl

--- a/packages/adblocker-webextension/test/index.test.ts
+++ b/packages/adblocker-webextension/test/index.test.ts
@@ -191,6 +191,16 @@ describe('html-filtering', () => {
       });
       expect(shouldApplyReplaceSelectors(request)).to.be.false;
     });
+
+    it('rejects requests with content-disposition headers without the value of inline', () => {
+      const request = createRequestWithDetails({
+        type: 'script',
+        headers: {
+          'content-disposition': 'attachment',
+        },
+      });
+      expect(shouldApplyReplaceSelectors(request)).to.be.false;
+    });
   });
 
   context('respects MAXIMUM_RESPONSE_BUFFER_SIZE', () => {

--- a/packages/adblocker-webextension/test/index.test.ts
+++ b/packages/adblocker-webextension/test/index.test.ts
@@ -204,7 +204,7 @@ describe('html-filtering', () => {
       public status: WebRequest.StreamFilterStatus = 'uninitialized';
       public error: string = '';
 
-      private isResumable() {
+      private isResumable(): boolean {
         return (
           this.status !== 'closed' && this.status !== 'failed' && this.status !== 'disconnected'
         );
@@ -246,13 +246,13 @@ describe('html-filtering', () => {
         this._pulled = next;
       }
 
-      public _ondata(event: WebRequest.StreamFilterEventData) {
+      public _ondata(event: WebRequest.StreamFilterEventData): void {
         this.write(event.data);
       }
 
-      public _noop() {}
+      public _noop(): void {}
 
-      public _push(data: ArrayBuffer | Uint8Array, isLast: boolean = false) {
+      public _push(data: ArrayBuffer | Uint8Array, isLast: boolean = false): void {
         if (this.status !== 'transferringdata' && this.status !== 'uninitialized') {
           this.error = 'Further data transfer cannot be done since the stream is already closed!';
           this.onerror({

--- a/packages/adblocker-webextension/test/index.test.ts
+++ b/packages/adblocker-webextension/test/index.test.ts
@@ -7,20 +7,21 @@ import { NetworkFilter } from '@cliqz/adblocker';
 import {
   fromWebRequestDetails,
   updateResponseHeadersWithCSP,
-  OnBeforeRequestDetailsType,
   getHostnameHashesFromLabelsBackward,
   shouldApplyReplaceSelectors,
   filterRequestHTML,
   MAXIMUM_RESPONSE_BUFFER_SIZE,
   HTMLSelector,
+  OnHeadersReceivedDetailsType,
 } from '../src/index.js';
 
 describe('#updateResponseHeadersWithCSP', () => {
-  const baseDetails: OnBeforeRequestDetailsType = {
+  const baseDetails: OnHeadersReceivedDetailsType = {
     requestId: '42',
     tabId: 42,
     type: 'main_frame',
     url: 'https://foo.com',
+    statusCode: 200,
   };
 
   it('does not update if no policies', () => {
@@ -34,7 +35,12 @@ describe('#updateResponseHeadersWithCSP', () => {
   });
 
   it('create csp header if not exist', () => {
-    expect(updateResponseHeadersWithCSP({ ...baseDetails, responseHeaders: [] }, 'CSP')).to.eql({
+    expect(
+      updateResponseHeadersWithCSP(
+        { ...baseDetails, responseHeaders: [], statusCode: 200 },
+        'CSP',
+      ),
+    ).to.eql({
       responseHeaders: [{ name: 'content-security-policy', value: 'CSP' }],
     });
   });
@@ -42,7 +48,11 @@ describe('#updateResponseHeadersWithCSP', () => {
   it('leaves other headers unchanged', () => {
     expect(
       updateResponseHeadersWithCSP(
-        { ...baseDetails, responseHeaders: [{ name: 'header1', value: 'value1' }] },
+        {
+          ...baseDetails,
+          responseHeaders: [{ name: 'header1', value: 'value1' }],
+          statusCode: 200,
+        },
         'CSP',
       ),
     ).to.eql({

--- a/packages/adblocker-webextension/test/index.test.ts
+++ b/packages/adblocker-webextension/test/index.test.ts
@@ -212,12 +212,6 @@ describe('html-filtering', () => {
 
       private _noop(): void {}
 
-      private isResumable(): boolean {
-        return (
-          this.status !== 'closed' && this.status !== 'failed' && this.status !== 'disconnected'
-        );
-      }
-
       public create(_requestId: number, _addonId: string): void {
         throw new Error('StreamFilter.create() is not implemented!');
       }
@@ -227,7 +221,11 @@ describe('html-filtering', () => {
       }
 
       public resume(): void {
-        if (this.isResumable() === false) {
+        if (
+          this.status !== 'closed' &&
+          this.status !== 'failed' &&
+          (this.status !== 'disconnected') === false
+        ) {
           this.error = 'This instance is not resumable!';
           this.onerror({
             data: Uint8Array.from([]),

--- a/packages/adblocker-webextension/test/index.test.ts
+++ b/packages/adblocker-webextension/test/index.test.ts
@@ -1,11 +1,17 @@
 import { expect } from 'chai';
 import 'mocha';
 
+import { WebRequest } from 'webextension-polyfill-ts';
+
 import {
   fromWebRequestDetails,
   updateResponseHeadersWithCSP,
   OnBeforeRequestDetailsType,
   getHostnameHashesFromLabelsBackward,
+  OnHeadersReceivedDetailsType,
+  shouldApplyReplaceSelectors,
+  filterRequestHTML,
+  MAXIMUM_RESPONSE_BUFFER_SIZE,
 } from '../src/index.js';
 
 describe('#updateResponseHeadersWithCSP', () => {
@@ -122,6 +128,216 @@ describe('#fromWebRequestDetails', () => {
       sourceHostnameHashes: getHostnameHashesFromLabelsBackward('sub.source.com', 'source.com'),
 
       type: 'script',
+    });
+  });
+});
+
+describe('html-filtering', () => {
+  context('#shouldApplyReplaceSelectors', () => {
+    function createWebRequestDetails({
+      responseType,
+      headers,
+    }: {
+      responseType: WebRequest.ResourceType;
+      headers: Record<string, string>;
+    }) {
+      const url = 'https://foo.com/';
+      const requestId = 'req-01';
+      const tabId = 1;
+      const details: OnHeadersReceivedDetailsType = {
+        requestId,
+        tabId,
+        url,
+        responseHeaders: Object.entries(headers).map(([name, value]) => ({
+          name,
+          value,
+        })),
+        type: responseType,
+      };
+
+      return details;
+    }
+
+    const sets: Array<Parameters<typeof createWebRequestDetails>[0] & { result: boolean }> = [
+      {
+        responseType: 'main_frame',
+        headers: {
+          'content-type': 'text/html',
+        },
+        result: true,
+      },
+      {
+        responseType: 'script',
+        headers: {
+          'content-type': 'application/javascript',
+        },
+        result: true,
+      },
+      {
+        responseType: 'stylesheet',
+        headers: {},
+        result: true,
+      },
+      {
+        responseType: 'script',
+        headers: {
+          'content-type': 'application/javascript',
+          'content-length': (MAXIMUM_RESPONSE_BUFFER_SIZE + 1).toString(),
+        },
+        result: false,
+      },
+    ];
+
+    sets.forEach((set) => {
+      const details = createWebRequestDetails(set);
+      const request = fromWebRequestDetails(details);
+
+      it(`${set.result ? 'allows' : 'rejects'} filtering ${set.responseType} type of ${set.headers['content-type']}`, () => {
+        expect(shouldApplyReplaceSelectors(request, details)).to.be.eql(set.result);
+      });
+    });
+  });
+
+  describe('#MAXIMUM_RESPONSE_BUFFER_SIZE', () => {
+    class StreamFilter implements WebRequest.StreamFilter {
+      public _pushed: number = 0;
+      public _pulled: Uint8Array = new Uint8Array();
+
+      public ondata: (data: WebRequest.StreamFilterEventData) => void = this._ondata;
+      public onstart: (data: WebRequest.StreamFilterEventData) => void = this._noop;
+      public onstop: (data: WebRequest.StreamFilterEventData) => void = this._ondata;
+      public onerror: (data: WebRequest.StreamFilterEventData) => void = this._noop;
+
+      public status: WebRequest.StreamFilterStatus = 'uninitialized';
+      public error: string = '';
+
+      private isResumable() {
+        return (
+          this.status !== 'closed' && this.status !== 'failed' && this.status !== 'disconnected'
+        );
+      }
+
+      public create(_requestId: number, _addonId: string): void {
+        throw new Error('StreamFilter.create() is not implemented!');
+      }
+
+      public suspend(): void {
+        this.status = 'suspended';
+      }
+
+      public resume(): void {
+        if (this.isResumable() === false) {
+          this.error = 'This instance is not resumable!';
+          this.onerror({
+            data: Uint8Array.from([]),
+          });
+          return;
+        }
+        this.status = 'transferringdata';
+      }
+
+      public close(): void {
+        this.status = 'closed';
+      }
+
+      public disconnect(): void {
+        this.status = 'disconnected';
+        this.ondata = this._ondata;
+        this.onstop = this._noop;
+      }
+
+      public write(data: ArrayBuffer | Uint8Array): void {
+        const next = new Uint8Array(this._pulled.byteLength + data.byteLength);
+        next.set(this._pulled);
+        next.set(new Uint8Array(data), this._pulled.byteLength);
+        this._pulled = next;
+      }
+
+      public _ondata(event: WebRequest.StreamFilterEventData) {
+        this.write(event.data);
+      }
+
+      public _noop() {}
+
+      public _push(data: ArrayBuffer | Uint8Array, isLast: boolean = false) {
+        if (
+          this.status !== 'transferringdata' &&
+          this.status !== 'uninitialized' &&
+          this.status !== 'disconnected'
+        ) {
+          this.error = 'Further data transfer cannot be done since the stream is already closed!';
+          this.onerror({
+            data: Uint8Array.from([]),
+          });
+          return;
+        }
+
+        if (this._pushed === 0) {
+          this.status = 'transferringdata';
+        }
+
+        this.ondata({ data });
+        if (isLast === true) {
+          this.onstop({ data: Uint8Array.from([]) });
+          this.status = 'finishedtransferringdata';
+        }
+      }
+
+      public _reset() {
+        this._pulled = new Uint8Array();
+        this._pushed = 0;
+        this.status = 'uninitialized';
+        this.error = '';
+        this.ondata = this._ondata;
+        this.onstart = this._noop;
+        this.onstop = this._ondata;
+        this.onerror = this._noop;
+      }
+    }
+
+    it('stops processing more than MAXIMUM_RESPONSE_BUFFER_SIZE', () => {
+      const streamFilter = new StreamFilter();
+      const details: OnHeadersReceivedDetailsType = {
+        responseHeaders: [
+          {
+            name: 'content-type',
+            value: 'text/text',
+          },
+        ],
+        url: 'https://foo.com/script.js',
+        type: 'main_frame',
+        originUrl: 'https://foo.com/',
+        tabId: 0,
+        requestId: 'req-00',
+      };
+      const request = fromWebRequestDetails(details);
+
+      function filterResponseData(_requestId: string): WebRequest.StreamFilter {
+        return streamFilter;
+      }
+
+      filterRequestHTML(filterResponseData, request, [['replace', [new RegExp('a', 'g'), 'b']]]);
+
+      // Fill MAXIMUM_RESPONSE_BUFFER_SIZE
+      const NOISE_BUFFER_SIZE = 1024 * 1024;
+      for (
+        let i = 0, noise = Uint8Array.from(new Array(NOISE_BUFFER_SIZE).fill('a'.charCodeAt(0)));
+        i < MAXIMUM_RESPONSE_BUFFER_SIZE;
+        i += NOISE_BUFFER_SIZE
+      ) {
+        streamFilter._push(noise);
+      }
+
+      streamFilter._push(Uint8Array.from(['b'.charCodeAt(0)]), true);
+
+      let sum = 0;
+      for (const octet of streamFilter._pulled) {
+        sum += octet;
+      }
+
+      streamFilter._reset();
+
+      expect(sum).to.be.eql('b'.charCodeAt(0) * (MAXIMUM_RESPONSE_BUFFER_SIZE + 1));
     });
   });
 });

--- a/packages/adblocker-webextension/test/index.test.ts
+++ b/packages/adblocker-webextension/test/index.test.ts
@@ -35,12 +35,7 @@ describe('#updateResponseHeadersWithCSP', () => {
   });
 
   it('create csp header if not exist', () => {
-    expect(
-      updateResponseHeadersWithCSP(
-        { ...baseDetails, responseHeaders: [], statusCode: 200 },
-        'CSP',
-      ),
-    ).to.eql({
+    expect(updateResponseHeadersWithCSP({ ...baseDetails, responseHeaders: [] }, 'CSP')).to.eql({
       responseHeaders: [{ name: 'content-security-policy', value: 'CSP' }],
     });
   });
@@ -51,7 +46,6 @@ describe('#updateResponseHeadersWithCSP', () => {
         {
           ...baseDetails,
           responseHeaders: [{ name: 'header1', value: 'value1' }],
-          statusCode: 200,
         },
         'CSP',
       ),
@@ -157,6 +151,7 @@ describe('html-filtering', () => {
         tabId: 1,
         url: 'https://foo.com/',
         type,
+        statusCode: 200,
         responseHeaders: Object.entries(headers).map(([name, value]) => ({
           name,
           value,
@@ -323,6 +318,7 @@ describe('html-filtering', () => {
       type: 'main_frame',
       originUrl: 'https://foo.com/',
       tabId: 0,
+      statusCode: 200,
       requestId: 'req-00',
     });
 

--- a/packages/adblocker-webextension/test/index.test.ts
+++ b/packages/adblocker-webextension/test/index.test.ts
@@ -8,7 +8,6 @@ import {
   updateResponseHeadersWithCSP,
   OnBeforeRequestDetailsType,
   getHostnameHashesFromLabelsBackward,
-  OnHeadersReceivedDetailsType,
   shouldApplyReplaceSelectors,
   filterRequestHTML,
   MAXIMUM_RESPONSE_BUFFER_SIZE,
@@ -159,7 +158,7 @@ describe('html-filtering', () => {
           'content-type': 'text/html',
         },
       });
-      expect(shouldApplyReplaceSelectors(request, request._originalRequestDetails)).to.be.true;
+      expect(shouldApplyReplaceSelectors(request)).to.be.true;
     });
 
     it('accepts script response with content-type header of application/javascript', () => {
@@ -169,7 +168,7 @@ describe('html-filtering', () => {
           'content-type': 'application/javascript',
         },
       });
-      expect(shouldApplyReplaceSelectors(request, request._originalRequestDetails)).to.be.true;
+      expect(shouldApplyReplaceSelectors(request)).to.be.true;
     });
 
     it('accepts stylesheet response without additional context', () => {
@@ -177,7 +176,7 @@ describe('html-filtering', () => {
         type: 'stylesheet',
         headers: {},
       });
-      expect(shouldApplyReplaceSelectors(request, request._originalRequestDetails)).to.be.true;
+      expect(shouldApplyReplaceSelectors(request)).to.be.true;
     });
 
     it('rejects script response larger than MAXIMUM_RESPONSE_BUFFER_SIZE', () => {
@@ -188,7 +187,7 @@ describe('html-filtering', () => {
           'content-length': (MAXIMUM_RESPONSE_BUFFER_SIZE + 1).toString(),
         },
       });
-      expect(shouldApplyReplaceSelectors(request, request._originalRequestDetails)).to.be.false;
+      expect(shouldApplyReplaceSelectors(request)).to.be.false;
     });
   });
 
@@ -288,7 +287,7 @@ describe('html-filtering', () => {
         originUrl: 'https://foo.com/',
         tabId: 0,
         requestId: 'req-00',
-      } as OnHeadersReceivedDetailsType);
+      });
 
       function filterResponseData(_requestId: string): WebRequest.StreamFilter {
         return streamFilter;

--- a/packages/adblocker-webextension/test/index.test.ts
+++ b/packages/adblocker-webextension/test/index.test.ts
@@ -260,11 +260,7 @@ describe('html-filtering', () => {
       public _noop() {}
 
       public _push(data: ArrayBuffer | Uint8Array, isLast: boolean = false) {
-        if (
-          this.status !== 'transferringdata' &&
-          this.status !== 'uninitialized' &&
-          this.status !== 'disconnected'
-        ) {
+        if (this.status !== 'transferringdata' && this.status !== 'uninitialized') {
           this.error = 'Further data transfer cannot be done since the stream is already closed!';
           this.onerror({
             data: Uint8Array.from([]),

--- a/packages/adblocker-webextension/test/index.test.ts
+++ b/packages/adblocker-webextension/test/index.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import 'mocha';
 
 import { WebRequest } from 'webextension-polyfill-ts';
+import { NetworkFilter } from '@cliqz/adblocker';
 
 import {
   fromWebRequestDetails,
@@ -13,7 +14,6 @@ import {
   MAXIMUM_RESPONSE_BUFFER_SIZE,
   HTMLSelector,
 } from '../src/index.js';
-import { NetworkFilter } from '../../adblocker/dist/commonjs/index.js';
 
 describe('#updateResponseHeadersWithCSP', () => {
   const baseDetails: OnBeforeRequestDetailsType = {

--- a/packages/adblocker/src/html-filtering.ts
+++ b/packages/adblocker/src/html-filtering.ts
@@ -259,18 +259,20 @@ export default class StreamingHtmlFilter {
     this.modifiers = modifiers;
   }
 
-  public flush(): string {
+  public flush(applyHTMLFiltering: boolean = true): string {
     let out = this.buffer;
 
-    // If there's a modifier
-    if (this.modifiers.length !== 0) {
-      // If there's a pattern, process in priority.
-      if (this.patterns.length !== 0) {
-        const [tags, parsed, rest] = extractTagsFromHtml(this.buffer, 'script');
-        out = removeTagsFromHtml(parsed, selectTagsToRemove(this.patterns, tags)) + rest;
-      }
+    if (applyHTMLFiltering === true) {
+      // If there's a modifier
+      if (this.modifiers.length !== 0) {
+        // If there's a pattern, process in priority.
+        if (this.patterns.length !== 0) {
+          const [tags, parsed, rest] = extractTagsFromHtml(this.buffer, 'script');
+          out = removeTagsFromHtml(parsed, selectTagsToRemove(this.patterns, tags)) + rest;
+        }
 
-      out = applyModifiersToHtml(out, this.modifiers);
+        out = applyModifiersToHtml(out, this.modifiers);
+      }
     }
 
     this.buffer = '';

--- a/packages/adblocker/src/request.ts
+++ b/packages/adblocker/src/request.ts
@@ -213,7 +213,7 @@ function isThirdParty(
   return false;
 }
 
-export interface RequestInitialization<T = any> {
+export interface RequestInitialization<T = any | undefined> {
   requestId: string;
   tabId: number;
 
@@ -233,14 +233,14 @@ export interface RequestInitialization<T = any> {
   // * Electron.OnBeforeRequestListenerDetails
   // * puppeteer.Request
   // * webRequest details
-  _originalRequestDetails: T | undefined;
+  _originalRequestDetails: T;
 }
 
-export default class Request<T = any> {
+export default class Request<T = any | undefined> {
   /**
    * Create an instance of `Request` from raw request details.
    */
-  public static fromRawDetails<T = any>({
+  public static fromRawDetails<T = any | undefined>({
     requestId = '0',
     tabId = 0,
     url = '',
@@ -285,7 +285,7 @@ export default class Request<T = any> {
     });
   }
 
-  public readonly _originalRequestDetails: T | undefined;
+  public readonly _originalRequestDetails: T;
 
   public type: RequestType;
   public readonly isHttp: boolean;

--- a/packages/adblocker/src/request.ts
+++ b/packages/adblocker/src/request.ts
@@ -213,7 +213,7 @@ function isThirdParty(
   return false;
 }
 
-export interface RequestInitialization {
+export interface RequestInitialization<T = any> {
   requestId: string;
   tabId: number;
 
@@ -233,14 +233,14 @@ export interface RequestInitialization {
   // * Electron.OnBeforeRequestListenerDetails
   // * puppeteer.Request
   // * webRequest details
-  _originalRequestDetails: any | undefined;
+  _originalRequestDetails: T | undefined;
 }
 
-export default class Request {
+export default class Request<T = any> {
   /**
    * Create an instance of `Request` from raw request details.
    */
-  public static fromRawDetails({
+  public static fromRawDetails<T = any>({
     requestId = '0',
     tabId = 0,
     url = '',
@@ -251,7 +251,7 @@ export default class Request {
     sourceDomain,
     type = 'main_frame',
     _originalRequestDetails,
-  }: Partial<RequestInitialization>): Request {
+  }: Partial<RequestInitialization<T>>): Request<T> {
     url = url.toLowerCase();
 
     if (hostname === undefined || domain === undefined) {
@@ -285,7 +285,7 @@ export default class Request {
     });
   }
 
-  public readonly _originalRequestDetails: any | undefined;
+  public readonly _originalRequestDetails: T | undefined;
 
   public type: RequestType;
   public readonly isHttp: boolean;


### PR DESCRIPTION
- Put `has-text` and `replace` filters accordingly by checking the conditions (including mime check)
- Check accumulated buffer size in streaming filter and abort if more than 10 megabytes is received.
- Move performHTMLFiltering to onHeadersReceieved to determine by the content-type header from server