### PR TITLE
test: regression coverage for binary merge correctness gaps

### DIFF
--- a/packages/adblocker/test/engine/bucket/filters.test.ts
+++ b/packages/adblocker/test/engine/bucket/filters.test.ts
@@ -374,6 +374,26 @@ describe('#FiltersContainer', () => {
           );
         });
 
+        it('keeps distinct filters whose serialized bytes hash to the same key', () => {
+          const sourceAFilters = parseFilters('/alpha-one^', { debug: false }).networkFilters;
+          const sourceBFilters = parseFilters('/beta-two^', { debug: false }).networkFilters;
+          const sourceA = new FiltersContainer({
+            config,
+            deserialize: NetworkFilter.deserialize,
+            filters: sourceAFilters,
+          });
+          const sourceB = new FiltersContainer({
+            config,
+            deserialize: NetworkFilter.deserialize,
+            filters: sourceBFilters,
+          });
+
+          const colliding = (): bigint => 0n;
+          const merged = FiltersContainer.merge([sourceA, sourceB], { hashFunc: colliding });
+
+          expect(merged.getFilters()).to.have.length(2);
+        });
+
         it('passes valid serialized network filter ranges to the supplied hash function', () => {
           const filters = parseFilters('/alpha-one^\n/beta-two^', { debug: false }).networkFilters;
           const sourceA = new FiltersContainer({

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -22,6 +22,7 @@ import FilterEngine from '../../src/engine/engine.js';
 import { Metadata } from '../../src/engine/metadata.js';
 import { CosmeticFilter } from '../../src/index.js';
 import { Domains } from '../../src/engine/domains.js';
+import { Env } from '../../src/preprocessor.js';
 
 /**
  * Helper function used in the Engine tests. All the assertions are performed by
@@ -2340,6 +2341,75 @@ foo.com###selector
         expect(() => FilterEngine.merge([engine1, engine2])).to.throw(
           'resource checksum of all merged engines must match with the first one: "1" but got: "2"',
         );
+      });
+    });
+
+    context('useBinaryMerge', () => {
+      it('evaluates preprocessors against the default env', () => {
+        // A filter gated behind a condition that is false in the default `Env`
+        // must not match after merging — the legacy path enforces this through
+        // `update`, the binary path must produce the same exclusion set.
+        const conditional = `!#if env_undefined_in_default
+||preprocessed.com^
+!#endif`;
+        const opts = { loadPreprocessors: true };
+        const engineA = FilterEngine.parse(conditional, opts);
+        const engineB = FilterEngine.parse('||other.com^', opts);
+
+        const request = Request.fromRawDetails({ url: 'https://preprocessed.com/' });
+
+        const legacy = FilterEngine.merge([engineA, engineB]);
+        expect(legacy.match(request)).to.have.property('match', false);
+
+        const binary = FilterEngine.merge([engineA, engineB], { useBinaryMerge: true });
+        expect(binary.match(request)).to.have.property('match', false);
+      });
+
+      it('keeps preprocessor evaluation responsive to updateEnv', () => {
+        const conditional = `!#if ext_test_flag
+||preprocessed.com^
+!#endif`;
+        const opts = { loadPreprocessors: true };
+        const engineA = FilterEngine.parse(conditional, opts);
+        const engineB = FilterEngine.parse('||other.com^', opts);
+
+        const request = Request.fromRawDetails({ url: 'https://preprocessed.com/' });
+
+        const merged = FilterEngine.merge([engineA, engineB], { useBinaryMerge: true });
+
+        // Default env: condition is false → filter excluded.
+        expect(merged.match(request)).to.have.property('match', false);
+
+        // Flip the env: the filter should become active.
+        const env = new Env();
+        env.set('ext_test_flag', true);
+        merged.updateEnv(env);
+        expect(merged.match(request)).to.have.property('match', true);
+      });
+
+      it('produces an engine consistent with overrideConfig', () => {
+        // overrideConfig is honored at the top level but `binaryMerge` builds
+        // the merged buckets from `firstSource.config`. When override flips a
+        // layout-affecting setting like `enableCompression`, the engine's
+        // declared config and its serialized filter bytes diverge — round-trip
+        // through serialize/deserialize must still yield the same filters.
+        const engineA = FilterEngine.parse('||compression-flip.com^', {
+          enableCompression: false,
+        });
+        const engineB = FilterEngine.parse('||other.com^', {
+          enableCompression: false,
+        });
+
+        const merged = FilterEngine.merge([engineA, engineB], {
+          useBinaryMerge: true,
+          overrideConfig: { enableCompression: true },
+        });
+
+        const request = Request.fromRawDetails({ url: 'https://compression-flip.com/' });
+        expect(merged.match(request)).to.have.property('match', true);
+
+        const roundTripped = FilterEngine.deserialize(merged.serialize());
+        expect(roundTripped.match(request)).to.have.property('match', true);
       });
     });
   });

--- a/packages/adblocker/test/reverse-index.test.ts
+++ b/packages/adblocker/test/reverse-index.test.ts
@@ -479,6 +479,72 @@ wildcard
                   expect(index.getTokens()).to.eql(new Uint32Array(0));
                 });
 
+                it('keeps distinct filters whose serialized bytes hash to the same key', () => {
+                  const config = new Config();
+                  const indexA = new ReverseIndex({
+                    deserialize: NetworkFilter.deserialize,
+                    filters: parseFilters('/alpha-one^', { debug: false }).networkFilters,
+                    optimize: noopOptimizeNetwork,
+                    config,
+                  });
+                  const indexB = new ReverseIndex({
+                    deserialize: NetworkFilter.deserialize,
+                    filters: parseFilters('/beta-two^', { debug: false }).networkFilters,
+                    optimize: noopOptimizeNetwork,
+                    config,
+                  });
+
+                  const colliding = (): bigint => 0n;
+                  const merged = (ReverseIndex<NetworkFilter>).merge([indexA, indexB], {
+                    hashFunc: colliding,
+                  });
+
+                  expect(merged.getFilters()).to.have.length(2);
+                });
+
+                it('handles sources whose backing buffer overestimates filter bytes', () => {
+                  // `ReverseIndex.update` allocates an upper-bound buffer based on
+                  // `getSerializedSize`. When the estimate overshoots, the source
+                  // `view.buffer.byteLength` includes slack bytes after the last
+                  // filter, which must not corrupt the merged index.
+                  class OverestimatingNetworkFilter extends NetworkFilter {
+                    public getSerializedSize(compression: boolean): number {
+                      return super.getSerializedSize(compression) + 8;
+                    }
+                  }
+
+                  const config = new Config();
+                  const filtersA = parseFilters('/alpha-one^', { debug: false })
+                    .networkFilters.map(
+                      (f) => Object.setPrototypeOf(f, OverestimatingNetworkFilter.prototype) as NetworkFilter,
+                    );
+                  const filtersB = parseFilters('/beta-two^', { debug: false })
+                    .networkFilters.map(
+                      (f) => Object.setPrototypeOf(f, OverestimatingNetworkFilter.prototype) as NetworkFilter,
+                    );
+
+                  const indexA = new ReverseIndex({
+                    deserialize: NetworkFilter.deserialize,
+                    filters: filtersA,
+                    optimize: noopOptimizeNetwork,
+                    config,
+                  });
+                  const indexB = new ReverseIndex({
+                    deserialize: NetworkFilter.deserialize,
+                    filters: filtersB,
+                    optimize: noopOptimizeNetwork,
+                    config,
+                  });
+
+                  const merged = (ReverseIndex<NetworkFilter>).merge([indexA, indexB], {
+                    hashFunc,
+                  });
+
+                  const expected = parseFilters('/alpha-one^\n/beta-two^', { debug: false })
+                    .networkFilters;
+                  expect(merged.getFilters()).to.eql(expected);
+                });
+
                 it('serializes and deserializes a merged index', () => {
                   const config = new Config();
                   const indexA = new ReverseIndex({


### PR DESCRIPTION
## Summary

Adds failing regression tests for four correctness gaps in the binary merge path introduced in ghostery/adblocker#5631. Each test asserts the expected (correct) behavior, so they fail on the current branch and would pass once the underlying bug is fixed.

| Test | Issue |
|---|---|
| `FiltersContainer#merge` — *keeps distinct filters whose serialized bytes hash to the same key* | `filtersByHash.set` overwrites on collision, silently dropping a distinct filter |
| `ReverseIndex#merge` — *keeps distinct filters whose serialized bytes hash to the same key* | Same issue in the reverse-index dedupe map |
| `ReverseIndex#merge` — *handles sources whose backing buffer overestimates filter bytes* | `aligned.push(source.view.buffer.byteLength)` includes slack from `update`'s upper-bound allocation; sequential `getFilters()` deserialization drifts past the slack |
| `FiltersEngine#merge useBinaryMerge` — *evaluates preprocessors against the default env* | `binaryMerge` assigns `new PreprocessorBucket({ preprocessors })` without calling `updateEnv`, so `excluded` stays empty and gated filters become active |
| `FiltersEngine#merge useBinaryMerge` — *keeps preprocessor evaluation responsive to updateEnv* | Confirms the same issue still manifests before any later `updateEnv` call |
| `FiltersEngine#merge useBinaryMerge` — *produces an engine consistent with overrideConfig* | Buckets are built from `firstSource.config`, so `overrideConfig.enableCompression` desyncs the engine header from the bucket bytes; the merged engine no longer round-trips through `serialize` → `deserialize` |

The hash-collision tests inject a constant `hashFunc` to force a deterministic collision — this is currently the only way to exercise that path since the public `FilterEngine.merge` API does not expose `hashFunc`. That API gap is itself part of the first issue.

The slack-bytes test uses an `OverestimatingNetworkFilter` subclass that inflates `getSerializedSize`, mirroring the `OverestimatingFilter` pattern already in `bucket/filters.test.ts`.

## Test plan

- [ ] `npx mocha 'test/engine/bucket/filters.test.ts'` — 2 new failures, the rest still pass
- [ ] `npx mocha 'test/reverse-index.test.ts'` — 8 new failures (4 hash collision + 4 slack bytes, across compression × optimize), the rest still pass
- [ ] `npx mocha 'test/engine/engine.test.ts' --grep '#merge'` — 3 new failures, the rest still pass