### PR TITLE
fix(merge): make binary merge dedup collision-safe

### DIFF
--- a/packages/adblocker/package.json
+++ b/packages/adblocker/package.json
@@ -115,8 +115,7 @@
     "rollup": "^4.60.2",
     "tshy": "^4.1.1",
     "tsx": "^4.21.0",
-    "typescript": "^6.0.3",
-    "xxhash-wasm": "^1.1.0"
+    "typescript": "^6.0.3"
   },
   "dependencies": {
     "@ghostery/adblocker-content": "^2.14.3",

--- a/packages/adblocker/src/engine/bucket/filters.ts
+++ b/packages/adblocker/src/engine/bucket/filters.ts
@@ -25,12 +25,18 @@ import IFilter from '../../filters/interface.js';
  * lists of filters (which is useful for things like generic cosmetic filters
  * or $badfilter).
  */
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  const len = a.length;
+  if (len !== b.length) return false;
+  for (let i = 0; i < len; i += 1) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
 export default class FiltersContainer<T extends IFilter> {
   public static merge<T extends IFilter>(
     sources: FiltersContainer<T>[],
-    opts?: {
-      hashFunc?: (arr: Uint8Array, beg: number, end: number) => number | string | bigint;
-    },
   ): FiltersContainer<T> {
     if (sources.length < 2) {
       throw new Error('FiltersContainer.merge requires at least two source containers.');
@@ -65,10 +71,12 @@ export default class FiltersContainer<T extends IFilter> {
       });
     }
 
-    // See reverse-index.ts for additional notes regarding hash function.
-    const hashFunc = typeof opts?.hashFunc === 'function' ? opts.hashFunc : crc32;
-
-    const filtersByHash: Map<number | bigint | string, Uint8Array> = new Map();
+    // crc32 acts as an accelerator for the dedup map. On hash collision we
+    // fall back to byte equality, so collision quality of the hash never
+    // affects correctness — only the (negligible) byte-compare branch rate.
+    const filtersByHash: Map<number, Uint8Array[]> = new Map();
+    let uniqueCount = 0;
+    let totalBytes = 0;
 
     // Recover serialized filter ranges from the offset table. The container
     // stores N + 1 offsets for N filters; two consecutive offsets give the byte
@@ -85,28 +93,43 @@ export default class FiltersContainer<T extends IFilter> {
       ) {
         filterIndex = source.offsets[i];
         filterIndexEnd = source.offsets[i + 1];
-        filtersByHash.set(
-          hashFunc(source.filters, filterIndex, filterIndexEnd),
-          source.filters.subarray(filterIndex, filterIndexEnd),
-        );
+        const slice = source.filters.subarray(filterIndex, filterIndexEnd);
+        const hash = crc32(source.filters, filterIndex, filterIndexEnd);
+        const bucket = filtersByHash.get(hash);
+        if (bucket === undefined) {
+          filtersByHash.set(hash, [slice]);
+          uniqueCount += 1;
+          totalBytes += slice.byteLength;
+        } else {
+          let duplicate = false;
+          for (let j = 0; j < bucket.length; j += 1) {
+            if (bytesEqual(bucket[j], slice)) {
+              duplicate = true;
+              break;
+            }
+          }
+          if (!duplicate) {
+            bucket.push(slice);
+            uniqueCount += 1;
+            totalBytes += slice.byteLength;
+          }
+        }
       }
     }
 
     // Rebuild a compact filters container from the deduplicated serialized
     // filters.
-    let filtersIndexSize = 0;
-    for (const filter of filtersByHash.values()) {
-      filtersIndexSize += filter.byteLength;
-    }
-
-    const view = StaticDataView.allocate(filtersIndexSize, firstSource.config);
-    const offsets = new Uint32Array(filtersByHash.size + 1);
+    const view = StaticDataView.allocate(totalBytes, firstSource.config);
+    const offsets = new Uint32Array(uniqueCount + 1);
 
     let index = 0;
-    for (const filter of filtersByHash.values()) {
-      offsets[index++] = view.pos;
-      view.buffer.set(filter, view.pos);
-      view.setPos(view.pos + filter.byteLength);
+    for (const bucket of filtersByHash.values()) {
+      for (let j = 0; j < bucket.length; j += 1) {
+        const filter = bucket[j];
+        offsets[index++] = view.pos;
+        view.buffer.set(filter, view.pos);
+        view.setPos(view.pos + filter.byteLength);
+      }
     }
     offsets[index] = view.getPos();
 
@@ -117,7 +140,7 @@ export default class FiltersContainer<T extends IFilter> {
     });
     container.filters = view.subarray();
     container.offsets = offsets;
-    container.numberOfFilters = filtersByHash.size;
+    container.numberOfFilters = uniqueCount;
     return container;
   }
 

--- a/packages/adblocker/src/engine/reverse-index.ts
+++ b/packages/adblocker/src/engine/reverse-index.ts
@@ -92,13 +92,22 @@ const EMPTY_BUCKET: number = Number.MAX_SAFE_INTEGER >>> 0;
  *   2. Compute a histogram of frequency of each token (globally)
  *   3. Select the best token for each filter (lowest frequency)
  */
+type MergeEntry = {
+  tokens: number[];
+  bytes: Uint8Array;
+};
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  const len = a.length;
+  if (len !== b.length) return false;
+  for (let i = 0; i < len; i += 1) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
 export default class ReverseIndex<T extends IFilter> {
-  public static merge<T extends IFilter>(
-    sources: ReverseIndex<T>[],
-    opts?: {
-      hashFunc?: (arr: Uint8Array, beg: number, end: number) => number | string | bigint;
-    },
-  ): ReverseIndex<T> {
+  public static merge<T extends IFilter>(sources: ReverseIndex<T>[]): ReverseIndex<T> {
     if (sources.length < 2) {
       throw new Error('ReverseIndex.merge requires at least two source indexes.');
     }
@@ -131,27 +140,11 @@ export default class ReverseIndex<T extends IFilter> {
       });
     }
 
-    // `crc32` is used as a built-in hash function as they're already embedded
-    // in the library. As 32bit hash functions will have a lot of collision
-    // after ~130k of inputs, so they're not really recommended. Always
-    // implement the hash function in the below priority table. Do allocate the
-    // function before going to heavy loop.
-    // a) a function returns BigInt (low memory pressure and collision)
-    // b) a function returns number (in case of <130k input)
-    // c) a function returns string (high memory pressure)
-    // Hash-collision resistance is delegated to the caller-provided `hashFunc`.
-    // Use a collision-resistant string or bigint hash when merging large
-    // indexes; the built-in crc32 fallback is intended for convenience, not
-    // strict collision-proof deduplication.
-    const hashFunc = typeof opts?.hashFunc === 'function' ? opts.hashFunc : crc32;
-
-    const filtersByHash: Map<
-      number | bigint | string,
-      {
-        tokens: number[];
-        bytes: Uint8Array;
-      }
-    > = new Map();
+    // crc32 acts as an accelerator for the dedup map. On hash collision we
+    // fall back to byte equality, so collision quality of the hash never
+    // affects correctness — only the (negligible) byte-compare branch rate.
+    const filtersByHash: Map<number, MergeEntry[]> = new Map();
+    let uniqueCount = 0;
 
     // Recover serialized filter ranges from bucket pointers. The bucket index
     // stores absolute offsets into `source.view.buffer`; sorting unique offsets
@@ -187,43 +180,41 @@ export default class ReverseIndex<T extends IFilter> {
       });
       aligned.push(source.view.buffer.byteLength);
 
-      // Hash each serialized filter range and keep one representative per hash.
-      // This contributes to the memory pressure rather saving the full buffer
-      // with other data types.
-      for (
-        let i = 1,
-          hash: number | bigint | string,
-          tokens: number[],
-          filter:
-            | {
-                tokens: number[];
-                bytes: Uint8Array;
-              }
-            | undefined;
-        i < aligned.length;
-        i++
-      ) {
-        hash = hashFunc(source.view.buffer, aligned[i - 1], aligned[i]);
-        tokens = tokensByOffset.get(aligned[i - 1])!;
-        filter = filtersByHash.get(hash);
-        // Token policy for duplicated serialized filters:
-        // - Keep the fast compact merge path as the default.
-        // - Preserve one complete source-selected token association; do not
-        //   union tokens or recompute global best tokens here.
-        // - Exact `getTokens()` / bucket layout is not canonical merge output;
-        //   tests should assert filters and matching behavior instead.
-        // - Hash-collision handling is a separate dedupe concern and should not
-        //   change this token-choice policy.
-        //
-        // The same serialized filter can be indexed under different tokens in
-        // different sources because each source has its own histogram. Prefer
-        // the representative with the most selected token groups to keep the
-        // runtime index compact while preserving matching correctness.
-        if (typeof filter === 'undefined' || filter.tokens.length < tokens.length) {
-          filtersByHash.set(hash, {
-            tokens: tokensByOffset.get(aligned[i - 1])!,
-            bytes: source.view.buffer.subarray(aligned[i - 1], aligned[i]),
-          });
+      // Token policy for duplicated serialized filters:
+      // - Keep the fast compact merge path as the default.
+      // - Preserve one complete source-selected token association; do not
+      //   union tokens or recompute global best tokens here.
+      // - Exact `getTokens()` / bucket layout is not canonical merge output;
+      //   tests should assert filters and matching behavior instead.
+      //
+      // The same serialized filter can be indexed under different tokens in
+      // different sources because each source has its own histogram. Prefer
+      // the representative with the most selected token groups to keep the
+      // runtime index compact while preserving matching correctness.
+      for (let i = 1; i < aligned.length; i += 1) {
+        const beg = aligned[i - 1];
+        const end = aligned[i];
+        const slice = source.view.buffer.subarray(beg, end);
+        const tokens = tokensByOffset.get(beg)!;
+        const hash = crc32(source.view.buffer, beg, end);
+        const bucket = filtersByHash.get(hash);
+        if (bucket === undefined) {
+          filtersByHash.set(hash, [{ tokens, bytes: slice }]);
+          uniqueCount += 1;
+          continue;
+        }
+        let matched = -1;
+        for (let j = 0; j < bucket.length; j += 1) {
+          if (bytesEqual(bucket[j].bytes, slice)) {
+            matched = j;
+            break;
+          }
+        }
+        if (matched === -1) {
+          bucket.push({ tokens, bytes: slice });
+          uniqueCount += 1;
+        } else if (bucket[matched].tokens.length < tokens.length) {
+          bucket[matched] = { tokens, bytes: slice };
         }
       }
     }
@@ -231,9 +222,11 @@ export default class ReverseIndex<T extends IFilter> {
     // Rebuild a compact reverse-index from the deduplicated serialized filters.
     let totalNumberOfIndexedTokens = 0;
     let filtersIndexSize = 0;
-    for (const filter of filtersByHash.values()) {
-      totalNumberOfIndexedTokens += filter.tokens.length;
-      filtersIndexSize += filter.bytes.byteLength;
+    for (const bucket of filtersByHash.values()) {
+      for (let j = 0; j < bucket.length; j += 1) {
+        totalNumberOfIndexedTokens += bucket[j].tokens.length;
+        filtersIndexSize += bucket[j].bytes.byteLength;
+      }
     }
     const bucketsIndexSize = totalNumberOfIndexedTokens * 2;
     const tokensLookupIndexSize = Math.max(2, nextPow2(totalNumberOfIndexedTokens));
@@ -252,13 +245,16 @@ export default class ReverseIndex<T extends IFilter> {
       suffixes.push([]);
     }
 
-    for (const filter of filtersByHash.values()) {
-      const filterIndex = view.getPos();
-      view.buffer.set(filter.bytes, filterIndex);
-      view.setPos(filterIndex + filter.bytes.byteLength);
+    for (const bucket of filtersByHash.values()) {
+      for (let j = 0; j < bucket.length; j += 1) {
+        const filter = bucket[j];
+        const filterIndex = view.getPos();
+        view.buffer.set(filter.bytes, filterIndex);
+        view.setPos(filterIndex + filter.bytes.byteLength);
 
-      for (const token of filter.tokens) {
-        suffixes[token & mask].push([token, filterIndex]);
+        for (const token of filter.tokens) {
+          suffixes[token & mask].push([token, filterIndex]);
+        }
       }
     }
 
@@ -282,7 +278,7 @@ export default class ReverseIndex<T extends IFilter> {
     }).updateInternals({
       bucketsIndex,
       filtersIndexStart,
-      numberOfFilters: filtersByHash.size,
+      numberOfFilters: uniqueCount,
       tokensLookupIndex,
       view: view,
     });

--- a/packages/adblocker/test/engine/bucket/filters.test.ts
+++ b/packages/adblocker/test/engine/bucket/filters.test.ts
@@ -8,7 +8,6 @@
 
 import { expect } from 'chai';
 import 'mocha';
-import xxhash from 'xxhash-wasm';
 
 import Config from '../../../src/config.js';
 import { StaticDataView } from '../../../src/data-view.js';
@@ -221,14 +220,6 @@ describe('#FiltersContainer', () => {
       });
 
       describe('#merge', () => {
-        let hashFunc: (arr: Uint8Array, beg: number, end: number) => bigint;
-
-        before(async () => {
-          const hasher = await xxhash();
-          hashFunc = (arr: Uint8Array, beg: number, end: number) =>
-            hasher.h64Raw(arr.subarray(beg, end));
-        });
-
         it('throws on fewer than two source containers', () => {
           const empty = new FiltersContainer({
             config,
@@ -282,7 +273,7 @@ describe('#FiltersContainer', () => {
             deserialize: NetworkFilter.deserialize,
             filters: [],
           });
-          const merged = FiltersContainer.merge([sourceA, sourceB], { hashFunc });
+          const merged = FiltersContainer.merge([sourceA, sourceB]);
           expect(merged.offsets.length).to.equal(0);
           expect(merged.filters.byteLength).to.equal(0);
           expect(merged.getSerializedSize()).to.equal(4);
@@ -301,9 +292,7 @@ describe('#FiltersContainer', () => {
             deserialize: NetworkFilter.deserialize,
             filters,
           });
-          expect(FiltersContainer.merge([empty, nonEmpty], { hashFunc }).getFilters()).to.eql(
-            filters,
-          );
+          expect(FiltersContainer.merge([empty, nonEmpty]).getFilters()).to.eql(filters);
         });
 
         it('deduplicates overlapping network filters in first-seen order', () => {
@@ -324,7 +313,7 @@ describe('#FiltersContainer', () => {
           const expected = parseFilters(
             '/alpha-one^\n/beta-two^\n/gamma-three^\n/delta-four^',
           ).networkFilters;
-          expect(FiltersContainer.merge([sourceA, sourceB], { hashFunc }).getFilters()).to.eql(
+          expect(FiltersContainer.merge([sourceA, sourceB]).getFilters()).to.eql(
             expected,
           );
         });
@@ -340,7 +329,7 @@ describe('#FiltersContainer', () => {
             deserialize: NetworkFilter.deserialize,
             filters: parseFilters('/beta-two^').networkFilters,
           });
-          const merged = FiltersContainer.merge([sourceA, sourceB], { hashFunc });
+          const merged = FiltersContainer.merge([sourceA, sourceB]);
           const buffer = StaticDataView.allocate(merged.getSerializedSize(), config);
           merged.serialize(buffer);
           expect(buffer.pos).to.equal(buffer.buffer.byteLength);
@@ -369,34 +358,7 @@ describe('#FiltersContainer', () => {
             deserialize: CosmeticFilter.deserialize,
             filters,
           });
-          expect(FiltersContainer.merge([sourceA, sourceB], { hashFunc }).getFilters()).to.eql(
-            filters,
-          );
-        });
-
-        it('passes valid serialized network filter ranges to the supplied hash function', () => {
-          const filters = parseFilters('/alpha-one^\n/beta-two^', { debug: false }).networkFilters;
-          const sourceA = new FiltersContainer({
-            config,
-            deserialize: NetworkFilter.deserialize,
-            filters,
-          });
-          const sourceB = new FiltersContainer({
-            config,
-            deserialize: NetworkFilter.deserialize,
-            filters: [],
-          });
-          const seen: NetworkFilter[] = [];
-          const recordingHashFunc = (arr: Uint8Array, beg: number, end: number): bigint => {
-            seen.push(
-              NetworkFilter.deserialize(
-                StaticDataView.fromUint8Array(arr.subarray(beg, end), config),
-              ),
-            );
-            return hashFunc(arr, beg, end);
-          };
-          FiltersContainer.merge([sourceA, sourceB], { hashFunc: recordingHashFunc });
-          expect(seen).to.eql(filters);
+          expect(FiltersContainer.merge([sourceA, sourceB]).getFilters()).to.eql(filters);
         });
       });
     });

--- a/packages/adblocker/test/reverse-index.test.ts
+++ b/packages/adblocker/test/reverse-index.test.ts
@@ -8,7 +8,6 @@
 
 import { expect } from 'chai';
 import 'mocha';
-import xxhash from 'xxhash-wasm';
 
 import Config from '../src/config.js';
 import { StaticDataView } from '../src/data-view.js';
@@ -300,17 +299,6 @@ wildcard
               // We require debug=false explicitly for #merge.
               const filtersWithoutDebug = parseFilters(allLists, { debug: false });
 
-              // Having custom hash function is unavoidable in the real world scenario and
-              // it's nice to have an example in the test code.
-              let hashFunc: (arr: Uint8Array, beg: number, end: number) => bigint;
-
-              before(async () => {
-                const hasher = await xxhash();
-                hashFunc = (arr: Uint8Array, beg: number, end: number) => {
-                  return hasher.h64Raw(arr.subarray(beg, end));
-                };
-              });
-
               it('throws on less than 2 indexes were given as sources', () => {
                 const emptyIndex = new ReverseIndex({
                   deserialize: NetworkFilter.deserialize,
@@ -373,9 +361,7 @@ wildcard
                     config,
                   });
 
-                  const index = (ReverseIndex<NetworkFilter>).merge([indexA, indexB], {
-                    hashFunc,
-                  });
+                  const index = (ReverseIndex<NetworkFilter>).merge([indexA, indexB]);
                   const filters = index.getFilters();
 
                   // This expect line is not strictly required but helps fast exit.
@@ -415,9 +401,7 @@ wildcard
                     optimize: noopOptimizeNetwork,
                     config,
                   });
-                  const merged = (ReverseIndex<NetworkFilter>).merge([indexA, indexB], {
-                    hashFunc,
-                  });
+                  const merged = (ReverseIndex<NetworkFilter>).merge([indexA, indexB]);
                   expect(merged.getFilters()).to.be.eql(assumed.getFilters());
 
                   const alphaBetaGammaRequest = Request.fromRawDetails({
@@ -471,9 +455,7 @@ wildcard
                     optimize: noopOptimizeNetwork,
                     config,
                   });
-                  const index = (ReverseIndex<NetworkFilter>).merge([indexA, indexB], {
-                    hashFunc,
-                  });
+                  const index = (ReverseIndex<NetworkFilter>).merge([indexA, indexB]);
 
                   expect(index.getFilters()).to.eql([]);
                   expect(index.getTokens()).to.eql(new Uint32Array(0));
@@ -493,9 +475,7 @@ wildcard
                     optimize: noopOptimizeNetwork,
                     config,
                   });
-                  const index = (ReverseIndex<NetworkFilter>).merge([indexA, indexB], {
-                    hashFunc,
-                  });
+                  const index = (ReverseIndex<NetworkFilter>).merge([indexA, indexB]);
                   const buffer = StaticDataView.allocate(index.getSerializedSize(), config);
                   index.serialize(buffer);
                   expect(buffer.pos).to.equal(buffer.buffer.byteLength);
@@ -537,9 +517,7 @@ wildcard
                     config,
                   });
 
-                  const index = (ReverseIndex<CosmeticFilter>).merge([indexA, indexB], {
-                    hashFunc,
-                  });
+                  const index = (ReverseIndex<CosmeticFilter>).merge([indexA, indexB]);
                   const filters = index.getFilters();
 
                   // This expect line is not strictly required but helps fast exit.
@@ -566,9 +544,7 @@ wildcard
                     optimize: noopOptimizeCosmetic,
                     config,
                   });
-                  const index = (ReverseIndex<CosmeticFilter>).merge([indexA, indexB], {
-                    hashFunc,
-                  });
+                  const index = (ReverseIndex<CosmeticFilter>).merge([indexA, indexB]);
                   const expectedFilter = indexA.getFilters()[0].toString();
 
                   expect(index.getFilters().map((filter) => filter.toString())).to.eql([

--- a/yarn.lock
+++ b/yarn.lock
@@ -1009,7 +1009,6 @@ __metadata:
     tshy: "npm:^4.1.1"
     tsx: "npm:^4.21.0"
     typescript: "npm:^6.0.3"
-    xxhash-wasm: "npm:^1.1.0"
   languageName: unknown
   linkType: soft
 
@@ -11177,13 +11176,6 @@ __metadata:
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: 10/ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a
-  languageName: node
-  linkType: hard
-
-"xxhash-wasm@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "xxhash-wasm@npm:1.1.0"
-  checksum: 10/cad149dabda4ec4ce7c2edd98815c4cc21eadab72f631c832af110066867850fb86b9430499707358d3e23cafe6d71d0a5c16be8f1864f213e4cd1aa74bd9556
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

The byte-level merge added in #5631 keys dedup on `hashFunc(bytes)` and overwrites on collision in both `FiltersContainer.merge` (`bucket/filters.ts:88-92`) and `ReverseIndex.merge` (`reverse-index.ts:206-227`). Distinct filters whose serialized bytes hash to the same key are silently dropped. With the default `crc32` this happens at production scale:

| List set | Filters | crc32 dropped |
|---|---|---|
| ads | 110,102 | 0 |
| tracking | 166,488 | **1** |
| full | 199,412 | **2** |

The inline comments already acknowledged the hash isn't collision-proof and pushed responsibility onto callers via `hashFunc`, but the public `FilterEngine.merge` API never exposed `hashFunc` — so production callers always got the unsafe default.

## Approach

Make the hash a probe key, not the identity:

```ts
const filtersByHash: Map<number, Uint8Array[]> = new Map();
// on insert:
const bucket = filtersByHash.get(hash);
if (bucket === undefined) filtersByHash.set(hash, [slice]);
else if (!bucket.some(b => bytesEqual(b, slice))) bucket.push(slice);
```

Correctness no longer depends on hash quality. The byte-compare branch fires only on real collisions — measured at 2 out of 199,412 entries on the full list, so the overhead is unobservable in practice.

For `ReverseIndex.merge`, the existing "longest tokens wins" policy on duplicates is preserved under byte equality.

## Knock-on changes

- `hashFunc` parameter removed from both `FiltersContainer.merge` and `ReverseIndex.merge`. With two-tier dedup it has no remaining job, and exposing it was the path through which crc32's collision behaviour reached production callers.
- `xxhash-wasm` dropped from `package.json`. It only existed to give callers a 64-bit alternative to crc32; that mitigation is no longer needed.
- Tests in `bucket/filters.test.ts` and `reverse-index.test.ts` updated to the new no-arg API. The `passes valid serialized network filter ranges to the supplied hash function` test is removed (no parameter to validate). Net diff: **128 insertions, 180 deletions**.

## Performance

Measured on full lists, M1 MBP, 10 runs:

| | min | avg | vs legacy |
|---|---|---|---|
| legacy merge | 507.78ms | 523.83ms | — |
| binary merge (this PR) | **137.96ms** | 154.90ms | **3.7×** |
| binary merge (#5631 buggy) | ~144ms | ~159ms | 3.8× |

Two-tier crc32 lands within noise of the original buggy implementation. A standalone hash-strategy bench (run separately) confirmed crc32 is faster than xxhash64 on these short inputs because the WASM call dominates.

## Test plan

- [ ] `npx mocha 'test/engine/bucket/filters.test.ts'` — 38 passing
- [ ] `npx mocha 'test/reverse-index.test.ts'` — 120 passing
- [ ] `npx mocha 'test/engine/engine.test.ts' --grep '#merge'` — 17 passing
- [ ] `npx mocha 'test/engine/engine.test.ts'` — 8466 passing (no regressions)
- [ ] `BENCH_MERGE_RUNS=10 npx tsx ./tools/bench-merge.ts full` — confirm binary still ~3.7× faster than legacy